### PR TITLE
Simultaneous punishment prevention (Mars-8)

### DIFF
--- a/src/main/kotlin/network/warzone/mars/player/feature/PlayerService.kt
+++ b/src/main/kotlin/network/warzone/mars/player/feature/PlayerService.kt
@@ -14,12 +14,10 @@ import network.warzone.mars.punishment.models.Punishment
 import network.warzone.mars.rank.exceptions.RankAlreadyPresentException
 import network.warzone.mars.rank.exceptions.RankMissingException
 import network.warzone.mars.rank.models.Rank
-import network.warzone.mars.tag.TagFeature
 import network.warzone.mars.tag.exceptions.TagAlreadyPresentException
 import network.warzone.mars.tag.exceptions.TagMissingException
 import network.warzone.mars.tag.exceptions.TagNotPresentException
 import network.warzone.mars.tag.models.Tag
-import network.warzone.mars.utils.mapErrorSmart
 import network.warzone.mars.utils.parseHttpException
 import java.util.*
 

--- a/src/main/kotlin/network/warzone/mars/punishment/PunishmentService.kt
+++ b/src/main/kotlin/network/warzone/mars/punishment/PunishmentService.kt
@@ -23,7 +23,10 @@ object PunishmentService {
     ): Boolean {
 
         val request = parseHttpException {
-            ApiClient.get<Boolean>("/mc/players/$player/punishmentProtection")
+            ApiClient.post<Boolean, PlayerPunishmentProtectionRequest>(
+                "/mc/players/$player/punishmentProtection",
+                PlayerPunishmentProtectionRequest(player, false)
+            )
         }
 
         val status = request.getOrNull()

--- a/src/main/kotlin/network/warzone/mars/punishment/PunishmentService.kt
+++ b/src/main/kotlin/network/warzone/mars/punishment/PunishmentService.kt
@@ -8,6 +8,7 @@ import network.warzone.mars.api.socket.models.SimplePlayer
 import network.warzone.mars.player.feature.exceptions.PlayerMissingException
 import network.warzone.mars.punishment.exceptions.PunishmentAlreadyRevertedException
 import network.warzone.mars.punishment.exceptions.PunishmentMissingException
+import network.warzone.mars.punishment.models.PlayerPunishmentProtectionRequest
 import network.warzone.mars.punishment.models.Punishment
 import network.warzone.mars.punishment.models.PunishmentAction
 import network.warzone.mars.punishment.models.PunishmentReason
@@ -16,6 +17,52 @@ import network.warzone.mars.utils.parseHttpException
 import java.util.*
 
 object PunishmentService {
+
+    suspend fun isProtected(
+        player: SimplePlayer
+    ): Boolean {
+
+        val request = parseHttpException {
+            ApiClient.get<Boolean>("/mc/players/$player/punishmentProtection")
+        }
+
+        val status = request.getOrNull()
+        if (status != null) return status
+
+        request.onFailure {
+            when (it.code) {
+                ApiExceptionType.PLAYER_MISSING -> throw PlayerMissingException(player.name)
+                else -> TODO("Unexpected API exception: ${it.code}")
+            }
+        }
+
+        throw RuntimeException("Unreachable")
+    }
+
+    suspend fun protect(
+        player: SimplePlayer
+    ): Boolean {
+
+        val request = parseHttpException {
+            ApiClient.post<Boolean, PlayerPunishmentProtectionRequest>(
+                "/mc/players/$player/punishmentProtection",
+                PlayerPunishmentProtectionRequest(player, true)
+            )
+        }
+
+        val status = request.getOrNull()
+        if (status != null) return status
+
+        request.onFailure {
+            when (it.code) {
+                ApiExceptionType.PLAYER_MISSING -> throw PlayerMissingException(player.name)
+                else -> TODO("Unexpected API exception: ${it.code}")
+            }
+        }
+
+        throw RuntimeException("Unreachable")
+    }
+
     suspend fun create(
         reason: PunishmentReason,
         offence: Int,

--- a/src/main/kotlin/network/warzone/mars/punishment/models/Punishment.kt
+++ b/src/main/kotlin/network/warzone/mars/punishment/models/Punishment.kt
@@ -1,5 +1,6 @@
 package network.warzone.mars.punishment.models
 
+import kotlinx.serialization.Serializable
 import network.warzone.mars.api.socket.models.SimplePlayer
 import network.warzone.mars.feature.Resource
 import java.util.*
@@ -37,3 +38,5 @@ data class Punishment(
 data class PunishmentReason(val name: String, val message: String, val short: String)
 
 data class PunishmentReversion(val revertedAt: Long, val reverter: SimplePlayer, val reason: String)
+
+data class PlayerPunishmentProtectionRequest(val target: SimplePlayer, val apply: Boolean = false)


### PR DESCRIPTION
- [Add functionality to pull/push punishment protection status from the API](https://github.com/Warzone/mars/commit/267e2325280cb678dd67e0c1cb297ff5c9733a05)

Fixes the following issue:
[Prevent repeat / simultaneous / accidental punishments against a single user](https://github.com/Warzone/mars/issues/8)